### PR TITLE
Update metadata.json for GS 40 & 41.  Bump version.

### DIFF
--- a/SwitchFocusType@romano.rgtti.com/metadata.json
+++ b/SwitchFocusType@romano.rgtti.com/metadata.json
@@ -3,9 +3,11 @@
   "name": "Switch Focus Type",
   "original-authors": "Romano Giannetti <romano.giannetti@gmail.com>",
   "shell-version": [
-    "3.38"
+    "3.38",
+    "40",
+    "41"
   ],
   "url": "https://github.com/Rmano/gse-switch-focus-mode",
   "uuid": "SwitchFocusType@romano.rgtti.com",
-  "version": 5
+  "version": 6
 }


### PR DESCRIPTION
This is a straightforward update for Gnome Shell 40 and 41.
